### PR TITLE
Allow compilation with GCC 15

### DIFF
--- a/src/proctree.h
+++ b/src/proctree.h
@@ -41,7 +41,6 @@ struct proc_t {
 };
 
 int update_tree(void del(void*));
-int update_tree();
 struct proc_t* find_by_pid(int pid);
 struct proc_t* tree_start(int root, int start);
 struct proc_t* tree_next();

--- a/src/whowatch.c
+++ b/src/whowatch.c
@@ -243,7 +243,7 @@ werase(w->wd);
 	size_changed = 0;
 }
 
-static void winch_handler()
+static void winch_handler(int i)
 {
 	size_changed++;
 }

--- a/src/whowatch.h
+++ b/src/whowatch.h
@@ -185,7 +185,7 @@ void curses_init();
 void curses_end();
 
 /* proctree.c */
-int update_tree();
+int update_tree(void del(void*));
 
 /* plist.c */
 void delete_tree_line(void *line);


### PR DESCRIPTION
Remove/replace incorrect declarations of `update_tree`:

```
In file included from proctree.c:20:
proctree.h:22:5: error: conflicting types for ‘update_tree’; have ‘int(void)’
   22 | int update_tree();
      |     ^~~~~~~~~~~
proctree.h:21:5: note: previous declaration of ‘update_tree’ with type ‘int(void (*)(void *))’
   21 | int update_tree(void del(void*));
      |     ^~~~~~~~~~~
```

```
In file included from procinfo.c:9:
proctree.h:21:5: error: conflicting types for ‘update_tree’; have ‘int(void (*)(void *))’
   21 | int update_tree(void del(void*));
      |     ^~~~~~~~~~~
In file included from procinfo.c:8:
whowatch.h:167:5: note: previous declaration of ‘update_tree’ with type ‘int(void)’
  167 | int update_tree();
      |     ^~~~~~~~~~~
```

Fix signature of `winch_handler` signal handler, which must take an `int`:

```
whowatch.c: In function ‘set_sig’:
whowatch.c:239:26: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  239 |         signal(SIGWINCH, winch_handler);
      |                          ^~~~~~~~~~~~~
      |                          |
      |                          void (*)(void)
In file included from /usr/include/sys/wait.h:36,
                 from whowatch.c:2:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
whowatch.c:225:13: note: ‘winch_handler’ declared here
  225 | static void winch_handler()
      |             ^~~~~~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
```
